### PR TITLE
fix: remove duplicate default StorageClasses

### DIFF
--- a/k8s/clusters/kclt-01/apps/rook-ceph/rook-ceph/cluster/helm-release.yaml
+++ b/k8s/clusters/kclt-01/apps/rook-ceph/rook-ceph/cluster/helm-release.yaml
@@ -163,7 +163,7 @@ spec:
         storageClass:
             enabled: true
             name: ${CLUSTER_STORAGE_BLOCK_HDD}
-            isDefault: true 
+            isDefault: false 
             reclaimPolicy: Delete
             allowVolumeExpansion: true
             parameters:
@@ -185,7 +185,7 @@ spec:
         storageClass:
             enabled: true
             name: ${CLUSTER_STORAGE_BLOCK_SSD}
-            isDefault: true 
+            isDefault: false
             reclaimPolicy: Delete
             allowVolumeExpansion: true
             parameters:


### PR DESCRIPTION
Removes the HDD and SSD-exclusive classes from also being flagged as default.