### PR TITLE
Clean up rook-ceph

### DIFF
--- a/k8s/clusters/kclt-01/apps/rook-ceph/rook-ceph/cluster/helm-release.yaml
+++ b/k8s/clusters/kclt-01/apps/rook-ceph/rook-ceph/cluster/helm-release.yaml
@@ -25,13 +25,19 @@ spec:
       retries: 5
   values:
     operatorNamespace: rook-ceph
+    
+
     monitoring:
       enabled: true
       createPrometheusRules: true
+    
+
     configOverride: |
       [global]
       bdev_enable_discard = true
       bdev_async_discard = true
+    
+
     ingress:
       dashboard:
         ingressClassName: "nginx"
@@ -42,19 +48,25 @@ spec:
           - hosts:
             - *host
             secretName: *host 
+    
+
     cephClusterSpec:
       monitoring:
         # why are these like this.
         enabled: true
         metricsDisabled: false
+      
       network:
         provider: host
+      
       crashCollector:
         disable: false
+      
       dashboard:
         enabled: true
         urlPrefix: /
         ssl: false 
+      
       storage:
         # Set to false for safety, all nodes should be used though.
         useAllNodes: false
@@ -84,6 +96,7 @@ spec:
               - name: "/dev/disk/by-id/wwn-0x50000396f8329825"
               - name: "/dev/disk/by-id/wwn-0x50000396f8325515"
           #- name: amdusias
+      
       resources:
         mgr:
           limits:
@@ -133,7 +146,9 @@ spec:
           requests:
             cpu: "500m"
             memory: "100Mi"
-    cephBlockPools: 
+    
+
+    cephBlockPools:
       - name: ceph-blockpool
         spec:
           failureDomain: host
@@ -158,6 +173,7 @@ spec:
               csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
               csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
               csi.storage.k8s.io/fstype: ext4
+      
       - name: ceph-blockpool-hdd
         spec:
           failureDomain: host
@@ -180,6 +196,7 @@ spec:
               csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
               csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
               csi.storage.k8s.io/fstype: ext4
+      
       - name: ceph-blockpool-ssd
         spec:
           failureDomain: host
@@ -202,6 +219,12 @@ spec:
               csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
               csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
               csi.storage.k8s.io/fstype: ext4
+    
+
+    cephBlockPoolsVolumeSnapshotClass:
+      enabled: false
+
+
     cephFileSystems:
       - name: ceph-filesystem
         spec:
@@ -238,6 +261,7 @@ spec:
             csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
             csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
             csi.storage.k8s.io/fstype: ext4
+      
       - name: ceph-filesystem-hdd
         spec:
           metadataPool:
@@ -271,6 +295,7 @@ spec:
             csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
             csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
             csi.storage.k8s.io/fstype: ext4
+      
       - name: ceph-filesystem-ssd
         spec:
           metadataPool:
@@ -304,6 +329,8 @@ spec:
             csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
             csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
             csi.storage.k8s.io/fstype: ext4
+    
+
     cephObjectStores:
       - name: ceph-bucket
         spec:
@@ -335,5 +362,7 @@ spec:
           reclaimPolicy: Delete
           parameters:
             region: ${CLUSTER_NAME}
+    
+
     toolbox:
       enabled: true


### PR DESCRIPTION
In addition to making the `rook-ceph-cluster` chart more readable, it also disables `cephBlockPoolsVolumeSnapshotClass`