### PR TITLE
Flux tuning

### DIFF
--- a/k8s/clusters/kclt-01/apps/auth/authentik/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/auth/authentik/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -10,7 +11,7 @@ spec:
     #- name: cluster-apps-authentik-redis-cluster
     - name: cluster-apps-cert-manager-issuers
     - name: cluster-apps-rook-ceph-cluster
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/auth/authentik/app
+  path: ${CLUSTER_PATH}/apps/auth/authentik/app
   prune: true
   sourceRef:
     kind: GitRepository
@@ -20,6 +21,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -29,7 +31,7 @@ spec:
   dependsOn:
     - name: cluster-apps-cloudnative-pg
     - name: cluster-apps-rook-ceph-cluster
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/auth/authentik/cnpg-cluster
+  path: ${CLUSTER_PATH}/apps/auth/authentik/cnpg-cluster
   prune: true
   sourceRef:
     kind: GitRepository
@@ -39,6 +41,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
 #---
+## yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 #apiVersion: kustomize.toolkit.fluxcd.io/v1
 #kind: Kustomization
 #metadata:
@@ -48,7 +51,7 @@ spec:
 #  dependsOn:
 #    - name: cluster-apps-rook-ceph-cluster
 #    - name: cluster-apps-cert-manager-issuers
-#  path: ./k8s/clusters/${CLUSTER_NAME}/apps/auth/authentik/redis-cluster
+#  path: ${CLUSTER_PATH}/apps/auth/authentik/redis-cluster
 #  prune: true
 #  sourceRef:
 #    kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/cert-manager/cert-manager/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/cert-manager/cert-manager/ks.yaml
@@ -1,11 +1,12 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-cert-manager
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/cert-manager/cert-manager/app
+  path: ${CLUSTER_PATH}/apps/cert-manager/cert-manager/app
   prune: true
   sourceRef:
     kind: GitRepository
@@ -15,6 +16,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -23,7 +25,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-cert-manager
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/cert-manager/cert-manager/cluster-issuers
+  path: ${CLUSTER_PATH}/apps/cert-manager/cert-manager/cluster-issuers
   prune: true
   sourceRef:
     kind: GitRepository
@@ -33,6 +35,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -41,7 +44,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-cert-manager-issuers
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/cert-manager/cert-manager/certificates
+  path: ${CLUSTER_PATH}/apps/cert-manager/cert-manager/certificates
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/cert-manager/trust-manager/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/cert-manager/trust-manager/ks.yaml
@@ -1,11 +1,12 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-trust-manager
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/cert-manager/trust-manager/app
+  path: ${CLUSTER_PATH}/apps/cert-manager/trust-manager/app
   prune: true
   sourceRef:
     kind: GitRepository
@@ -15,6 +16,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -25,7 +27,7 @@ spec:
     - name: cluster-apps-cert-manager-issuers
     - name: cluster-apps-cert-manager-certs
     - name: cluster-apps-trust-manager
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/cert-manager/trust-manager/bundles
+  path: ${CLUSTER_PATH}/apps/cert-manager/trust-manager/bundles
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/csi-addons-system/csi-addons-controller-manager/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/csi-addons-system/csi-addons-controller-manager/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/k8s/clusters/kclt-01/apps/database/cloudnative-pg/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/database/cloudnative-pg/ks.yaml
@@ -1,11 +1,12 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-cloudnative-pg
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/database/cloudnative-pg/app
+  path: ${CLUSTER_PATH}/apps/database/cloudnative-pg/app
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/default/jellyfin/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/default/jellyfin/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -8,12 +9,12 @@ spec:
   dependsOn:
     - name: cluster-apps-cert-manager-issuers
     - name: cluster-apps-rook-ceph-cluster
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/default/jellyfin/app
+  path: ${CLUSTER_PATH}/apps/default/jellyfin/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/k8s/clusters/kclt-01/apps/default/minecraft/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/default/minecraft/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -7,12 +8,12 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-rook-ceph-cluster
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/default/minecraft
+  path: ${CLUSTER_PATH}/apps/default/minecraft
   prune: true
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false
   interval: 30m
   retryInterval: 1m
   timeout: 5m 

--- a/k8s/clusters/kclt-01/apps/flux-system/alerts/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/flux-system/alerts/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -7,7 +8,7 @@ metadata:
 spec:
   dependsOn:
     - name: flux-notification-provider-discord
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/flux-system/alerts/discord/
+  path: ${CLUSTER_PATH}/apps/flux-system/alerts/discord/
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/flux-system/providers/discord/webhook.sops.yaml
+++ b/k8s/clusters/kclt-01/apps/flux-system/providers/discord/webhook.sops.yaml
@@ -4,7 +4,7 @@ metadata:
     name: provider-webhook-private-discord
     namespace: flux-system
 stringData:
-    address: ENC[AES256_GCM,data:tfkbVsiD8XbdPU1C0sIsREGBuNwKjtuZ5DZyGhqG3OnZK1b5aGwmYSU0opS+QRu+t4CeDRDVShsQnydj0bjzrlYtl+I0cbfpqZBoX78XtWRF7poL012QK2daKkDOy+1a5AFBr70/sF/rgQAoYGEjOqZ4E70pQBHyUQ==,iv:2kOCgTt82XT6+WmxaDotZAEWjchvRyARA1m+on0+NqE=,tag:8ObCr2uPhZBV+AgN0NaI5w==,type:str]
+    address: ENC[AES256_GCM,data:DW1dVFZ7SCE9XEtRv8IVHsMuQyhQGbPk+QwjZ1SYIQZRfkLyTi0R/qozgROmLal1MGEyyyTQzhg1qHTw2KxubGXFpOl5IT+YqY26HRzUS+xsBGSd4DFY6hLR8c2777GI1qSJ6DDiPtXWWwfCEEOueZwCYOsEeXCbog==,iv:Q80/fvT+si2hsMxLZu9X3q2eRqW/WelJK/HwguIy0fk=,tag:6JuMTmo9zCErp4Mg34ljUg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -20,8 +20,8 @@ sops:
             enBONmR0dWZqOHdYQjRYMFovdkxhMkUKDf2+IT67TTr2Q5IdeOUzbln8h96RKvC8
             iukIx4bOXuXJJxN8snMuqgxOVO/fbrYRw8P2H7kfLZlimqREQNy2eg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-10-04T22:33:12Z"
-    mac: ENC[AES256_GCM,data:V65fizIEc1IpBZ05I7Tcc4UmEKJEbJKoxYfQEsb1/3fjeKUawh6vdD2FuSL5KyoXvvtYr2CgbBE9xaiU1fiNhqy4AfzEggGOXm2FRu1SlED13iyt19QYjvrVQEw/uFyktHAGvn3FzCZlKiab+k0MZsZsdPG3q0Flrn04iULHmh4=,iv:8i6NI+8ti9HN8ej84pEm5Hh+2V/fi2zdaevZCX1+Y6M=,tag:FgQwFa5E2jwRAkxiMM6Rrw==,type:str]
+    lastmodified: "2023-10-22T20:36:02Z"
+    mac: ENC[AES256_GCM,data:bWpf/0217c7clxjB0f7bQVkTZFmbu4rBbHZKjx9F1m3f2XTLAoNgu1SzhTDqtZsMPzaFHROwf51nsKrsZZ6pSl6C9rqJpwlYdQtO0l1YXN65E12VE9JmqrSTvRNlTUu3czhZpyMCxoOjclxhHbfmUdeXrdv3hfPOmX9c5u/sScU=,iv:FrFH+Ab8455z7Hwb9S9uCn8INpVig0LQOoXj8r66TNs=,tag:LenXyV+4AQD73OvtmnvhSw==,type:str]
     pgp:
         - created_at: "2023-10-04T22:33:07Z"
           enc: |-

--- a/k8s/clusters/kclt-01/apps/flux-system/providers/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/flux-system/providers/ks.yaml
@@ -1,11 +1,12 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-notification-provider-discord
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/flux-system/providers/discord/
+  path: ${CLUSTER_PATH}/apps/flux-system/providers/discord/
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/kube-system/cilium/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/kube-system/cilium/ks.yaml
@@ -1,20 +1,22 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-cilium
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/kube-system/cilium/app
+  path: ${CLUSTER_PATH}/apps/kube-system/cilium/app
   prune: false # never should be deleted
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false
   interval: 30m
   retryInterval: 1m
   timeout: 5m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -23,7 +25,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-cilium
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/kube-system/cilium/configs
+  path: ${CLUSTER_PATH}/apps/kube-system/cilium/configs
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/kube-system/kubelet-csr-approver/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/kube-system/kubelet-csr-approver/ks.yaml
@@ -1,16 +1,17 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-kubelet-csr-approver
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/kube-system/kubelet-csr-approver/app
+  path: ${CLUSTER_PATH}/apps/kube-system/kubelet-csr-approver/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/k8s/clusters/kclt-01/apps/kube-system/vpa/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/kube-system/vpa/ks.yaml
@@ -1,16 +1,17 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-vpa
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/kube-system/vpa/app
+  path: ${CLUSTER_PATH}/apps/kube-system/vpa/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/k8s/clusters/kclt-01/apps/kyverno/kyverno/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/kyverno/kyverno/ks.yaml
@@ -1,20 +1,22 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-kyverno
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/kyverno/kverno/app
+  path: ${CLUSTER_PATH}/apps/kyverno/kverno/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false 
   interval: 30m
   retryInterval: 1m
   timeout: 5m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -23,7 +25,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-kyverno
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/kyverno/kverno/policies
+  path: ${CLUSTER_PATH}/apps/kyverno/kverno/policies
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/ks.yaml
@@ -1,18 +1,17 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-kube-prometheus-stack
   namespace: flux-system
 spec:
-  #dependsOn:
-  #  - name: # cluster-apps-otherExampleApp
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/monitoring/kube-prometheus-stack/app
+  path: ${CLUSTER_PATH}/apps/monitoring/kube-prometheus-stack/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/k8s/clusters/kclt-01/apps/networking/echo-server/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/networking/echo-server/ks.yaml
@@ -1,11 +1,12 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-echo-server
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/networking/echo-server/app
+  path: ${CLUSTER_PATH}/apps/networking/echo-server/app
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/networking/ingress-nginx/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/networking/ingress-nginx/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -7,7 +8,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-ingress-nginx-certificates
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/networking/ingress-nginx/app
+  path: ${CLUSTER_PATH}/apps/networking/ingress-nginx/app
   prune: true
   sourceRef:
     kind: GitRepository
@@ -17,6 +18,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -25,7 +27,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-cert-manager-issuers
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/networking/ingress-nginx/certificates
+  path: ${CLUSTER_PATH}/apps/networking/ingress-nginx/certificates
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/rook-ceph/rook-ceph/ks.yaml
@@ -1,20 +1,22 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-apps-rook-ceph-operator
   namespace: flux-system
 spec:
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/rook-ceph/rook-ceph/app
+  path: ${CLUSTER_PATH}/apps/rook-ceph/rook-ceph/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: ops
-  wait: true
+  wait: false
   interval: 30m
   retryInterval: 1m
   timeout: 15m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -23,7 +25,7 @@ metadata:
 spec:
   dependsOn:
     - name: cluster-apps-rook-ceph-operator
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/rook-ceph/rook-ceph/cluster
+  path: ${CLUSTER_PATH}/apps/rook-ceph/rook-ceph/cluster
   prune: true
   sourceRef:
     kind: GitRepository
@@ -33,6 +35,7 @@ spec:
   retryInterval: 1m
   timeout: 15m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -44,7 +47,7 @@ spec:
     - name: cluster-apps-rook-ceph-cluster
     - name: cluster-apps-cert-manager
     - name: cluster-apps-cert-manager-issuers
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/rook-ceph/rook-ceph/certificates
+  path: ${CLUSTER_PATH}/apps/rook-ceph/rook-ceph/certificates
   prune: true
   sourceRef:
     kind: GitRepository
@@ -54,6 +57,7 @@ spec:
   retryInterval: 1m
   timeout: 15m
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -63,7 +67,7 @@ spec:
   dependsOn:
     - name: cluster-apps-rook-ceph-operator
     - name: cluster-apps-rook-ceph-cluster
-  path: ./k8s/clusters/${CLUSTER_NAME}/apps/rook-ceph/rook-ceph/rook-direct-mount
+  path: ${CLUSTER_PATH}/apps/rook-ceph/rook-ceph/rook-direct-mount
   prune: true
   sourceRef:
     kind: GitRepository

--- a/k8s/clusters/kclt-01/flux/apps.yaml
+++ b/k8s/clusters/kclt-01/flux/apps.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/k8s/clusters/kclt-01/flux/global.yaml
+++ b/k8s/clusters/kclt-01/flux/global.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/k8s/clusters/kclt-01/flux/vars/cluster-configs.yaml
+++ b/k8s/clusters/kclt-01/flux/vars/cluster-configs.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cluster-configs
 data:
   CLUSTER_NAME: "kclt-01"
+  CLUSTER_PATH: "./k8s/clusters/kclt-01"
 
   TIMEZONE: "America/New_York"
   # cert-manager


### PR DESCRIPTION
This PR makes a minor change in adding a new flux variable `${CLUSTER_PATH}`, which allows the fluxtomize's `spec.path` to be slightly shortened. It also disables the `wait` for certain ks resources in an attempt to speed up reconciliation times.

In addition, it adds preliminary hooks for [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) (to be implemented at a later time)