### PR TITLE
Further expand capabilities of monitoring stack

### DIFF
--- a/k8s/clusters/kclt-01/apps/flux-system/alerts/discord/alert.yaml
+++ b/k8s/clusters/kclt-01/apps/flux-system/alerts/discord/alert.yaml
@@ -4,7 +4,7 @@ metadata:
   name: discord
   namespace: flux-system
 spec:
-  summary: "Cluster addons"
+  summary: "[KCLT-01] B@D Cluster addons"
   eventSeverity: "info"
   providerRef:
     name: discord

--- a/k8s/clusters/kclt-01/apps/monitoring/alertmanager/app/certificate.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/alertmanager/app/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "alertmanager.${CLUSTER_NAME}-api-${GLOBALSECRET__PUBLIC_DOMAIN/./-}"
+  namespace: monitoring
+spec:
+  secretName: "alertmanager.${CLUSTER_NAME}.api.${GLOBALSECRET__PUBLIC_DOMAIN}"
+  issuerRef:
+    name: "${CERT_DEFAULT_CLUSTERISSUER}"
+    kind: ClusterIssuer
+  commonName: "alertmanager.${CLUSTER_NAME}.api.${GLOBALSECRET__PUBLIC_DOMAIN}"
+  dnsNames:
+  - "alertmanager.${CLUSTER_NAME}.api.${GLOBALSECRET__PUBLIC_DOMAIN}"
+  - "*.alertmanager.${CLUSTER_NAME}.api.${GLOBALSECRET__PUBLIC_DOMAIN}"

--- a/k8s/clusters/kclt-01/apps/monitoring/alertmanager/app/helm-release.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/alertmanager/app/helm-release.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 2.0.3
+      interval: 30m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      main:
+        type: statefulset
+        statefulset:
+          volumeClaimTemplates:
+            - name: storage
+              accessMode: ReadWriteOnce
+              size: 50Mi
+              storageClass: ceph-block
+              globalMounts:
+                - path: /alertmanager
+      
+        containers:
+          main:
+            image:
+              repository: quay.io/prometheus/alertmanager
+              tag: v0.26.0
+            ports:
+              - name: http
+                containerPort: 9093
+            resources:
+              requests:
+                cpu: 11m
+                memory: 50M
+              limits:
+                memory: 100M
+    
+    
+    services:
+      main:
+        ports:
+          http:
+            port: 9093
+
+
+    ingress:
+      main:
+        enabled: true
+        className: nginx
+        hosts:
+          - host: &host alertmanager.${CLUSTER_NAME}.api.${GLOBALSECRET__PUBLIC_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  name: main
+                  port: http
+        tls:
+          - hosts:
+            - *host

--- a/k8s/clusters/kclt-01/apps/monitoring/alertmanager/app/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/alertmanager/app/kustomization.yaml
@@ -2,5 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helm-release.yaml
   - ./certificate.yaml
+  - ./helm-release.yaml

--- a/k8s/clusters/kclt-01/apps/monitoring/alertmanager/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/alertmanager/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-alertmanager
+  namespace: flux-system
+spec:
+  path: ${CLUSTER_PATH}/apps/monitoring/alertmanager/app
+  prune: true
+  dependsOn:
+    - name: cluster-apps-rook-ceph-cluster
+  sourceRef:
+    kind: GitRepository
+    name: ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/k8s/clusters/kclt-01/apps/monitoring/grafana/app/grafana-secrets.sops.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/grafana/app/grafana-secrets.sops.yaml
@@ -4,9 +4,9 @@ metadata:
     name: grafana-secrets
     namespace: monitoring
 stringData:
-    authentik-client_id: ENC[AES256_GCM,data:i30lzO9uDeotKYK3qUc42oDbUhaDkvTOCxYLId/NG4eTGdZhcL7VTg==,iv:u25jwIqdwlh0UPqnpppMGRr469h6PhczxshgpwYzUto=,tag:AMhCIaqZz2q0CAsoqq/Zeg==,type:str]
-    authentik-client_secret: ENC[AES256_GCM,data:FNpqCN8fhhb+nrhOsowiFLRWnKw1i6JQ4Z1/APzc66EH3XAJH0bXrwzUYaIfIbYmNgY2Eb2FM2qBILKKYn/zyra6bRFK9zwp853oXRgTi/NdrO/9xG7Nx1mdlOGJddN1QckKr4FWSujRZwckUneM7FTy1Wywoc5amewqSKq4NFs=,iv:T3Nm7FYhqhL28kTun/oN2+OZb3iU+CkbFs3g8IiSRw8=,tag:Ff5smF1BuYBVbCyrbs48Gg==,type:str]
-    authentik-roles: ENC[AES256_GCM,data:ZleVdO7fyQdO8HJ7ejiYU8d7czq1qgrP+dqIlzXqwNrMa5qAO5G1OhTvJxi7cgDDKI4fBcscCA==,iv:acrsk7iMlTK91vcazcK4QXvgt/cLLklomtXv+F/EXE0=,tag:Z9yg5u2iUje7yZpiX2ecag==,type:str]
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID: ENC[AES256_GCM,data:rQiPN49yAdV2rXl1hj6mcBt1U/jhxf07ZtqMz7492gKjSwKQcKo09g==,iv:9RIwrv0BYbJe64UIWibButwfs3dEOe1rZ9bq1StKw6Q=,tag:58TsT0qIdPZWdKDQtSwDBg==,type:str]
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:ut1mQZrXS4H6z5gU8O4Q9rIjHD/ZpVfNLACXGIdTjdfB8/y5vQC8TfWpvjuXMCRJqW47JRxvUdL6Z5SRp+b5IYuJZt0ilAsS9w+Ip4T/KgEjNnC8P35UX/gKzn3eJma7objaNe6SI946UsqESegFj51cP7a8Latlj97jPMD5uj4=,iv:X3I+r5lsfU9fd8FocqK70CuFPsI4zIQ70LAq5TRRNUE=,tag:F7QEz9P0SEua+MQSDCGbGQ==,type:str]
+    GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: ENC[AES256_GCM,data:j2E5+tD+DmfcpfQOe/9MgEcB9w/ozb6RiXDc3/bYQuhux5gRx1eXBvkNkto67otAmqvKWfJP/g==,iv:grnD2yj1sKbMa3FPOBihBty6Zw81hc0OY+C9crbk24w=,tag:OgBkVYREJe6LPl1gpjE5QQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -22,8 +22,8 @@ sops:
             blltaWIxZkI2K01oZHh2cHVybXBsUVkKtGVPe80ubpCC0cNNfXTKmoAx5s2a2h/O
             ufy6+0FO5tFZUUWZ10Auu8yCXHJUYwh0upQaYrV+b6yvW8vMFan/hw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-10-24T20:38:13Z"
-    mac: ENC[AES256_GCM,data:PhvuCC+dFgbKwyT3J0mKe3xSNydc6/nUM6JNHPPh9lHXaVwOnm1IZcwlIzFQydL38XtNUHT+G5k+vqMCq7/vJDAh+hoEtkmYQDnLG3AVK/6I/tnw2kFC2GxuBl94VzOlQ3n/ibgAIkkhwrp12Wbjw5op1ue5vX3AnJzh5Xi9W5E=,iv:+S4uDQAowHIAJumvd4CTTrI54QgvZMyWIEe1+XB+MMo=,tag:HjXGxrCR2c7dQVo4hLcM+w==,type:str]
+    lastmodified: "2023-10-29T00:00:17Z"
+    mac: ENC[AES256_GCM,data:GxufXT7eTTMPNovz8LzoPBuieBuliR8Eh8bPtyKEF6qe7nvPJIBCdrR1TSXQWQ7Amzgpusk3bYjdrljUsX5ZA6j8MQ3KKPMFopIWIID4VvQlJMcl+lEep6D2QsQlJZ8zJblaU6/KpHbwQMqYXfMcSbIMEHbq0Gt7lOnFfC3GYqo=,iv:bYgaozhYmfE5Nw7tShunizI/iM3sclpejvdyQmU5dCA=,tag:zKQxhGEsinqPCVAbG0tnmQ==,type:str]
     pgp:
         - created_at: "2023-10-24T20:20:37Z"
           enc: |-

--- a/k8s/clusters/kclt-01/apps/monitoring/grafana/app/helm-release.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/grafana/app/helm-release.yaml
@@ -33,6 +33,9 @@ spec:
       GF_DATABASE_SSL_MODE: disable
       INIT_POSTGRES_DBNAME: *dbName
       INIT_POSTGRES_HOST: "grafana-cnpg-rw.monitoring.svc.cluster.local"
+
+
+    envFromSecret: grafana-secret
     dashboardProviders:
       dashboardproviders.yaml:
         apiVersion: 1
@@ -53,12 +56,12 @@ spec:
               path: /var/lib/grafana/dashboards/node-exporter
             orgId: 1
             type: file
-          - name: unpoller
+          - name: infrastructure
             disableDeletion: false
             editable: true
-            folder: "UniFi Poller"
+            folder: "Cluster infrastructure"
             options:
-              path: /var/lib/grafana/dashboards/unpoller
+              path: /var/lib/grafana/dashboards/infrastructure
             orgId: 1
             type: file
     
@@ -84,7 +87,7 @@ spec:
           url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-pods.json
           datasource: Prometheus
       
-      infrastructure:
+      software:
         cert-manager:
           url: https://raw.githubusercontent.com/monitoring-mixins/website/master/assets/cert-manager/dashboards/cert-manager.json
           datasource: Prometheus
@@ -110,6 +113,29 @@ spec:
           url: https://raw.githubusercontent.com/fluxcd/flux2/main/manifests/monitoring/monitoring-config/dashboards/logs.json
           datasource: Prometheus
 
+      hardware:
+        unpoller-clients:
+          gnetId: 11315 # https://grafana.com/grafana/dashboards/11315
+          revision: 9
+          datasource:
+            - name: "DS_PROMETHEUS"
+              value: Prometheus
+        unpoller-usw:
+          gnetId: 11312 # https://grafana.com/grafana/dashboards/11312
+          revision: 9
+          datasource:
+            - name: "DS_PROMETHEUS"
+              value: Prometheus
+        unpoller-uap:
+          gnetId: 11314 # https://grafana.com/grafana/dashboards/11314
+          revision: 10
+          datasource:
+            - name: "DS_PROMETHEUS"
+              value: Prometheus
+        node-exporter: # https://grafana.com/grafana/dashboards/1860-node-exporter-full/
+          gnetId: 1860
+          revision: 29
+          datasource: Prometheus
 
     datasources:
       datasources.yaml:
@@ -126,7 +152,7 @@ spec:
             type: alertmanager
             uid: alertmanager
             access: proxy
-            url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
+            url: http://alertmanager.monitoring.svc.cluster.local:9093
             jsonData:
               implementation: prometheus
     deploymentStrategy:
@@ -181,18 +207,6 @@ spec:
     serviceMonitor:
       enabled: true
   valuesFrom:
-    - targetPath: env.GF_AUTH_GENERIC_OAUTH_CLIENT_ID
-      kind: Secret
-      name: grafana-secrets
-      valuesKey: authentik-client_id
-    - targetPath: env.GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET 
-      kind: Secret
-      name: grafana-secrets
-      valuesKey: authentik-client_secret
-    - targetPath: env.GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH
-      kind: Secret
-      name: grafana-secrets
-      valuesKey: authentik-roles
     - targetPath: env.GF_DATABASE_USER
       kind: Secret
       name: grafana-cnpg-user-grafana

--- a/k8s/clusters/kclt-01/apps/monitoring/grafana/app/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/grafana/app/kustomization.yaml
@@ -2,6 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - certificate.yaml
-  - grafana-secrets.sops.yaml
-  - helm-release.yaml
+  - ./certificate.yaml
+  - ./grafana-secrets.sops.yaml
+  - ./helm-release.yaml

--- a/k8s/clusters/kclt-01/apps/monitoring/grafana/cnpg-cluster/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/grafana/cnpg-cluster/kustomization.yaml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - backup.yaml
-  - cluster.yaml
-  - grafana-cnpg-user-grafana.sops.yaml
-  - grafana-cnpg-user-superuser.sops.yaml
-  - objectbucketclaim.yaml
+  - ./backup.yaml
+  - ./cluster.yaml
+  - ./grafana-cnpg-user-grafana.sops.yaml
+  - ./grafana-cnpg-user-superuser.sops.yaml
+  - ./objectbucketclaim.yaml

--- a/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/addons/alerts/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/addons/alerts/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helm-release.yaml
-  - ./certificate.yaml
+  - ./oomkilled.yaml 

--- a/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/addons/alerts/oomkilled.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/addons/alerts/oomkilled.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oom-alert
+  namespace: monitoring
+spec:
+  groups:
+    - name: oom
+      rules:
+        - alert: OOMKilled
+          annotations:
+            description: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has been OOMKilled {{ $value }} times in the last 10 minutes.
+          expr: (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1
+          labels:
+            severity: critical

--- a/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/addons/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/addons/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helm-release.yaml
-  - ./certificate.yaml
+  - ./alerts

--- a/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -27,6 +27,7 @@ spec:
   values:
     crds:
       enabled: true
+    cleanPrometheusOperatorObjectNames: true
 
 
     ###
@@ -175,13 +176,13 @@ spec:
                 - 10.64.6.12
                 - 10.64.6.13
                 - 10.64.6.14
-          - job_name: speedtest-exporter
-            scrape_interval: 60m
-            scrape_timeout: 60s
-            honor_timestamps: true
-            static_configs:
-              - targets:
-                - ???
+          #- job_name: speedtest-exporter
+          #  scrape_interval: 60m
+          #  scrape_timeout: 60s
+          #  honor_timestamps: true
+          #  static_configs:
+          #    - targets:
+          #      - ???
         enableAdminAPI: true
         externalLabels:
           cluster: ${CLUSTER_NAME}

--- a/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - helm-release.yaml
+  - ./helm-release.yaml

--- a/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/ks.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kube-prometheus-stack/ks.yaml
@@ -8,6 +8,28 @@ metadata:
 spec:
   path: ${CLUSTER_PATH}/apps/monitoring/kube-prometheus-stack/app
   prune: true
+  dependsOn:
+    - name: cluster-apps-alertmanager
+    - name: cluster-apps-rook-ceph-cluster
+  sourceRef:
+    kind: GitRepository
+    name: ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-kube-prometheus-stack-addons
+  namespace: flux-system
+spec:
+  path: ${CLUSTER_PATH}/apps/monitoring/kube-prometheus-stack/addons
+  prune: true
+  dependsOn:
+    - name: cluster-apps-kube-prometheus-stack
   sourceRef:
     kind: GitRepository
     name: ops

--- a/k8s/clusters/kclt-01/apps/monitoring/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/kustomization.yaml
@@ -2,9 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - grafana/ks.yaml
-  - goldilocks/ks.yaml
-  - kube-prometheus-stack/ks.yaml
-  - node-exporter/ks.yaml
-  - thanos/ks.yaml
+  - ./namespace.yaml
+  - ./alertmanager/ks.yaml
+  - ./grafana/ks.yaml
+  - ./goldilocks/ks.yaml
+  - ./kube-prometheus-stack/ks.yaml
+  - ./node-exporter/ks.yaml
+  - ./thanos/ks.yaml

--- a/k8s/clusters/kclt-01/apps/monitoring/node-exporter/app/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/node-exporter/app/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - helm-release.yaml
+  - ./helm-release.yaml

--- a/k8s/clusters/kclt-01/apps/monitoring/thanos/app/certificate.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/thanos/app/certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "thanos-${CLUSTER_NAME}-api-${GLOBALSECRET__PUBLIC_DOMAIN/./-}"
-  namespace: metrics
+  namespace: monitoring
 spec:
   secretName: "thanos.${CLUSTER_NAME}.api.${GLOBALSECRET__PUBLIC_DOMAIN}"
   issuerRef:

--- a/k8s/clusters/kclt-01/apps/monitoring/thanos/app/helm-release.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/thanos/app/helm-release.yaml
@@ -139,7 +139,7 @@ spec:
         enabled: true
       
       alertmanagers:
-        - http://kube-prometheus-stack-alertmanager.metrics:9093
+        - http://kube-prometheus-stack-alertmanager.monitoring:9093
       
       clusterName: ${CLUSTER_NAME}
       extraFlags:

--- a/k8s/clusters/kclt-01/apps/monitoring/thanos/app/kustomization.yaml
+++ b/k8s/clusters/kclt-01/apps/monitoring/thanos/app/kustomization.yaml
@@ -2,6 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - certificate.yaml
-  - helm-release.yaml
-  - object-bucket-claim.yaml 
+  - ./certificate.yaml
+  - ./helm-release.yaml
+  - ./object-bucket-claim.yaml 


### PR DESCRIPTION
This PR fixes some error within the previous implementation and adds support for Alertmanager

# New:

- Add alertmanager as a discrete item
- Expand grafana to use unpoller and reorganize dashboards

# Fixed

- Fixed typos in thanos, grafana which made services dysfunctional.

# Future

- Use [nginx external OAuth](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/) to easily lock down access to monitoring stack endpoints.
- Add support for Loki